### PR TITLE
Fix link to FOSUserBundle's User class doc

### DIFF
--- a/api-bundle/fosuser-bundle.md
+++ b/api-bundle/fosuser-bundle.md
@@ -4,7 +4,7 @@ This bundle is shipped with a bridge for the [FOSUserBundle](https://github.com/
 
 ## Creating a `User` entity with serialization groups
 
-Here's an example of declaration of a [doctrine ORM User class](https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Resources/doc/index.md#a-doctrine-orm-user-class). As shown you can use serialization groups to hide properties like `plainPassword` (only in read) and `password`. The properties shown are handled with the [`normalizationContext`](serialization-groups-and-relations.md#normalization), while the properties you can modify are handled with [`denormalizationContext`](serialization-groups-and-relations.md#denormalization).
+Here's an example of declaration of a [doctrine ORM User class](https://github.com/FriendsOfSymfony/FOSUserBundle/blob/master/Resources/doc/index.rst#a-doctrine-orm-user-class). As shown you can use serialization groups to hide properties like `plainPassword` (only in read) and `password`. The properties shown are handled with the [`normalizationContext`](serialization-groups-and-relations.md#normalization), while the properties you can modify are handled with [`denormalizationContext`](serialization-groups-and-relations.md#denormalization).
 
 First register the following service:
 


### PR DESCRIPTION
FOSUserBundle doc uses ReStructuredText instead of Markdown. The link to the User entity docs was broken because of this (used `.md` instead).