### PR TITLE
Error when following tutorial

### DIFF
--- a/getting-started/api.md
+++ b/getting-started/api.md
@@ -136,6 +136,7 @@ namespaces:
   entity: AppBundle\Entity # The default namespace for entities, following API Platform and Symfony best practices
 types: # The list of type to generated (a PHP entity class by type will be generated)
   BlogPosting: ~ # A type to generate a PHP entity class from, including all its properties (here this type has no specific property, they are all inherited)
+  SocialMediaPosting: ~
   Article: # Schema.org has an inheritance system, we will configure all types of the hierarchy
     properties: # The list of properties we want to use
       articleBody: ~


### PR DESCRIPTION
I encountered an error while following the tutorial. I'd attempt to generate-types for the provided schema, but would get this error:

[error] The type "SocialMediaPosting" (parent of "BlogPosting") doesn't exist

As a workaround, I added the SocialMediaPosting to the types and no error, but i'm not sure if any properties need to be exposed?