### PR TITLE
Introduce a Code Of Conduct

### DIFF
--- a/conduct.md
+++ b/conduct.md
@@ -1,0 +1,50 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery
+* Personal attacks
+* Trolling or insulting/derogatory comments
+* Public or private harassment
+* Publishing other's private information, such as physical or electronic
+  addresses, without explicit permission
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to
+fairly and consistently applying these principles to every aspect of managing
+this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting a project maintainer at [dunglas@gmail.com]. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. Maintainers are
+obligated to maintain confidentiality with regard to the reporter of an
+incident.
+
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.3.0, available at
+[http://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/

--- a/index.md
+++ b/index.md
@@ -4,3 +4,5 @@
 * [The schema generator](schema-generator/index.md)
 * [The API bundle](api-bundle/index.md)
 * [Deploying API Platform applications](deployment/index.md)
+
+* [Contributor Code Of Conduct](conduct.md)


### PR DESCRIPTION
To ensure the openness of the project, to show our commitment to a progressive vision of our societies and to show our strong opposition to sexism, all kinds of racism, homophobia and other forms of discriminations, I propose to add a contributor Code Of Conduct applying to all repositories under the umbrella of the [API Platform organization](https://github.com/api-platform/api-platform).

This Code Of Conduct is a verbatim copy of the [Contributor Covenant] version 1.3.0.

It's also a mark of strong support to the proposal of @ircmaxell of [adopting a Code of Conduct for PHP](https://wiki.php.net/rfc/adopt-code-of-conduct).

/cc @sroze @theofidry
