### PR TITLE
Add selflink restangular support

### DIFF
--- a/api-bundle/angular-integration.md
+++ b/api-bundle/angular-integration.md
@@ -18,7 +18,8 @@ var app = angular
 
         // JSON-LD @id support
         RestangularProvider.setRestangularFields({
-            id: '@id'
+            id: '@id',
+            selfLink: '@id'
         });
         RestangularProvider.setSelfLinkAbsoluteUrl(false);
 


### PR DESCRIPTION
This PR adds the [selfLink](https://github.com/mgonto/restangular#using-self-reference-resources) Restangular option in order to do : 

```javascript
Restangular.all('/images').getOne(...).then(image => {
    image.title = 'The new title';
    image.save();
});
```