### PR TITLE
Fix schema-generator getting-started

### DIFF
--- a/schema-generator/getting-started.md
+++ b/schema-generator/getting-started.md
@@ -64,7 +64,7 @@ types:
 
 Run the generator with this config file as parameter:
 
-    bin/schema generate-types output-directory/ address-book.yml
+    bin/schema generate-types output-directory/ app/config/address-book.yml
 
 The following classes will be generated:
 


### PR DESCRIPTION
Obligation to put the path to the configuration file.