### PR TITLE
Incorrect call to operation reference route

### DIFF
--- a/core/operations.md
+++ b/core/operations.md
@@ -194,7 +194,7 @@ use ApiPlatform\Core\Annotation\ApiResource;
 /**
  * @ApiResource(itemOperations={
  *     "get"={"method"="GET"},
- *     "special"={"special"={"route_name"="book_special"}
+ *     "special"={"route_name"="book_special"}
  * })
  */
 class Book


### PR DESCRIPTION
After testing in my app I fount that:
```"special"={"special"={"route_name"="book_special"}``` Do not work
```"special"={"route_name"="book_special"}``` Work